### PR TITLE
Style change in /business

### DIFF
--- a/frontend/src/components/BusinessItem.js
+++ b/frontend/src/components/BusinessItem.js
@@ -4,7 +4,7 @@ import Button from "react-bootstrap/Button";
 export const BusinessItem = (props) => {
   return (
     <>
-      <Button variant="outline-info" size="lg" active>
+      <Button variant="outline-info" onClick={props.onClick} active>
         {props.business.business_name}
       </Button>
     </>

--- a/frontend/src/pages/BusinessParticular/DisplayBusinessParticular.jsx
+++ b/frontend/src/pages/BusinessParticular/DisplayBusinessParticular.jsx
@@ -5,10 +5,12 @@ import { BusinessItem } from "../../components/BusinessItem";
 import { useNavigate } from "react-router-dom";
 import { useAuthContext } from "../../features/auth/authContext";
 import Button from "react-bootstrap/esm/Button";
+import { DisplayIndividualBusiness } from "./DisplayIndividualBusiness";
 
 export default function DisplayBusinessParticular() {
   const { businesses, dispatch } = useBusinessContext();
   const [businessesState, setBusinesses] = useState(businesses.businesses);
+  const [selectedBusiness, setSelectedBusiness] = useState("No selected business");
   const { user } = useAuthContext();
 
   const nav = useNavigate();
@@ -39,13 +41,45 @@ export default function DisplayBusinessParticular() {
 
   return (
     <>
-      <div className="d-grid gap-5">
-        {businessesState.map((business) => (
-          <BusinessItem business={business} key={business.business_id} />
-        ))}
-        <Button variant="secondary" size="lg" onClick={onClick}>
-          Add New
-        </Button>
+      <div className="row align-items-md-stretch">
+        <div className={selectedBusiness !== "No selected business" ? "col-md-4" : "container"}>
+          <div
+            className="container"
+            style={{
+              borderRight: "10px solid #ebebeb",
+              paddingBottom: "solid 5px",
+            }}
+          >
+            <div
+              className="container"
+              style={{
+                marginBottom: "30px",
+                fontSize: "20px",
+                fontWeight: "700",
+              }}
+            >
+              Your {businessesState.length > 1 ? "Businesses" : "Business"}
+            </div>
+            <div className="d-grid gap-5">
+              {businessesState.map((business) => (
+                <BusinessItem
+                  business={business}
+                  key={business.business_id}
+                  onClick={() => setSelectedBusiness(business)}
+                />
+              ))}
+              <Button variant="secondary" size="lg" onClick={onClick}>
+                Add New
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <div className={selectedBusiness !== "No selected business" ? "col-md-8" : "container"}>
+          <div className="container">
+            <DisplayIndividualBusiness business={selectedBusiness} />
+          </div>
+        </div>
       </div>
       <footer className="pt-3 mt-4 text-muted border-top">&copy; 2022</footer>
     </>

--- a/frontend/src/pages/BusinessParticular/DisplayIndividualBusiness.jsx
+++ b/frontend/src/pages/BusinessParticular/DisplayIndividualBusiness.jsx
@@ -1,0 +1,23 @@
+export const DisplayIndividualBusiness = (props) => {
+  const { business_name, categories, has_digitalized } = props.business;
+
+
+  return (
+    <>
+      <div className="heading border-bottom">
+        <div className="row">
+          <div className="col-md-12">
+            <h1 style={has_digitalized ? {} : { color: "rgb(119,119,119)" }}>
+              {business_name}
+            </h1>
+          </div>
+          <div className="col-md-12">
+            <h3 style={has_digitalized ? {} : { color: "rgb(119,119,119)" }}>
+              {categories}
+            </h3>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
For the `/business/` page, I rearranged some stuff so that when a business is selected, instead of opening a whole new page that requires us to render everything and fetch the data again, the page layout will change to something like this:

_**Before selecting**_
![image](https://user-images.githubusercontent.com/22293969/176880687-7146e3de-8fe1-4034-81f6-ef437fa42839.png)

_**After selecting**_
![image](https://user-images.githubusercontent.com/22293969/176879817-7e24dabd-ada8-44e2-95e8-509296f1dbfa.png)

The plan was to use the empty space on the second pic for editing the business/products and also for displaying the list of products (an outlet to the products page).

[**Branch**](https://github.com/florentianayuwono/DigitalIT/tree/backend-improve)
_(Yes, I know it's on the wrong branch but it was too late when I realized that something's wrong)_
@florentianayuwono can you check this branch (fetch, pull, and then run locally) and merge if everything's good to go. If everything's good, I can then go and finish creating the product feature and the rest of the basic features ASAP.